### PR TITLE
Fixed broken max torque for controller. default return val 0 for cont…

### DIFF
--- a/controller/controllerABC.py
+++ b/controller/controllerABC.py
@@ -15,9 +15,9 @@ class Controller(ABC):
         self.num_act = 1
 
     @abstractmethod
-    def get_torque(self, robot_state: ControlInput) -> float:
+    def get_torque(self, robot_state: ControlInput, max_torque: float) -> float:
         if not isinstance(robot_state, ControlInput):
             raise TypeError("robot_state must be an instance of RobotState from the controller module")
-        pass
+        return 0
 
 

--- a/controller/pidcontroller.py
+++ b/controller/pidcontroller.py
@@ -5,5 +5,5 @@ class PIDController(Controller):
         super().__init__()
         self.logger.info(f"{self.__class__.__name__} initialized")
             
-    def get_torque(self, robot_state: ControlInput) -> float:
-        return super().get_torque(robot_state)
+    def get_torque(self, robot_state: ControlInput, max_torque: float) -> float:
+        return super().get_torque(robot_state, max_torque)

--- a/controller/rlcontroller.py
+++ b/controller/rlcontroller.py
@@ -10,7 +10,7 @@ class RLController(Controller):
         self.logger.info(f"{self.__class__.__name__} initialized")
 
     def get_torque(self, robot_state: ControlInput, max_torque: float) -> float:
-        super().get_torque(robot_state)
+        super().get_torque(robot_state, max_torque) 
         list(robot_state)
         assert len(robot_state) == self.num_obs
 

--- a/controller/testcontroller.py
+++ b/controller/testcontroller.py
@@ -6,7 +6,7 @@ class TestController(Controller):
         self.MAX_TORQUE = .1
         self.logger.info(f"{self.__class__.__name__} initialized")
             
-    def get_torque(self, robot_state: ControlInput) -> float:
+    def get_torque(self, robot_state: ControlInput, max_torque) -> float:
         """ A generic test mode for the RWIP 
         """
         # TESTING: A simple control decision for testing

--- a/robot/RWIP.py
+++ b/robot/RWIP.py
@@ -104,7 +104,7 @@ class RobotSystem:
                 wheel_vel=0 if self.xmotor is None else self.xmotor.state['VELOCITY']
             )
 
-            # change to negative for the RL controller
+            # Change to negative convention due to motor
             torque_request = -self.controller.get_torque(control_input, self.MAX_TORQUE)
             self.robot_io.send_debug_data(torque_request=float(torque_request))
                         


### PR DESCRIPTION
…roller get_torque if not implemented

- Keeping any reference to RL outside of RWIP. 
- The torque should simply be inverted for _all_ controllers since this is a robot system property and not a controller property
- Base controller class has a return value of 0  for get_torque now, this prevents crashes from a partially implemented controller
- Added max torque to all controllers since any change in passed args needs to be uniform across all controllers.