### PR TITLE
downsampled data passed via /downsample/ channel

### DIFF
--- a/src/rluni/robot/RWIP.py
+++ b/src/rluni/robot/RWIP.py
@@ -146,7 +146,7 @@ class RobotSystem:
 
             # Debugging Data Example (add more data as needed)
             tele_debug_data = td.DebugData()
-            tele_debug_data.add_data(your_mama=69)
+            tele_debug_data.add_data(example_debug_data = 42)
 
             # Sensor reading and fusion
             imudata = td.IMUData(*self.imu.read_accelerometer_gyro(convert=True))


### PR DESCRIPTION
Downsampling on the server is not working well. 

Options:
- Grafana polls from influxdb with a refresh rate of 5s
- Telegraf downsamples and rebroadcasts to MQTT (I coulnb't get this to work after 4 hours of wrangling)

**Option C**

The MQTT process on the Jetson chooses every $n$th data packet signal being sent to it and rebroadcasts it over MQTT with a "downsampled/" prepended to the topic.

The Grafana dashboard has been updated to reflect this. To get a downsampled version of the data, simply prepend with a downsampled.

Main Grafana is working smooth now, full sample rate data is being added into the InfluxDB, tested with motors and without.

