### PR TITLE
watchdog timer

### DIFF
--- a/src/rluni/robot/robot.py
+++ b/src/rluni/robot/robot.py
@@ -479,6 +479,7 @@ class RobotSystem:
                     kd_scale=0.0,
                     feedforward_torque=torques.roll,
                     maximum_torque=self.MAX_TORQUE_ROLL_PITCH - 0.001,
+                    watchdog_timeout=0.1
                 )
             )
         if self.motors.pitch is not None:
@@ -489,6 +490,7 @@ class RobotSystem:
                     kd_scale=0.0,
                     feedforward_torque=torques.pitch,
                     maximum_torque=self.MAX_TORQUE_ROLL_PITCH - 0.001,
+                    watchdog_timeout=0.1
                 )
             )
         if self.motors.yaw is not None:
@@ -499,6 +501,7 @@ class RobotSystem:
                     kd_scale=0.0,
                     feedforward_torque=torques.yaw,
                     maximum_torque=self.MAX_TORQUE_YAW - 0.001,
+                    watchdog_timeout=0.1
                 )
             )
 


### PR DESCRIPTION
Just adds the watchdog timer flag to the torque requests. When no command is received by a moteus, it enters the timeout mode. Note that this is not a _fault_ state, just a different mode, i.e. the motors will _not_ turn off when the timeout is triggered.

Basic testing of unplugging the fdcanusb and jetson shows that the mode does in fact change. I checked on my own machine using the tview panel.